### PR TITLE
Fix HTTPS cloning in reporting workflow

### DIFF
--- a/.github/workflows/reporting.yaml
+++ b/.github/workflows/reporting.yaml
@@ -116,7 +116,7 @@ jobs:
 
       - name: "Clone Gerrit repositories for ${{ matrix.project }}"
         # Temporarily use fork until merged upstream
-        uses: modeseven-lfreleng-actions/gerrit-clone-action@initial-update
+        uses: modeseven-lfreleng-actions/gerrit-clone-action@main
         # uses: lfit/gerrit-clone-action@main
         id: clone
         with:
@@ -125,6 +125,7 @@ jobs:
           skip-archived: "true"
           threads: "4"
           clone-timeout: "300"
+          use-https: "true"
 
       - name: "Analyze cloned repository structure for ${{ matrix.project }}"
         shell: bash
@@ -234,7 +235,8 @@ jobs:
           egress-policy: 'audit'
 
       - name: "Download all analysis results"
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: analysis-results-*
           path: ./results


### PR DESCRIPTION
This PR fixes the gerrit-clone action to use HTTPS instead of SSH for anonymous repository cloning.

## Changes Made

1. **Updated action reference**: Changed from `@initial-update` to `@main` to use the latest version with HTTPS support
2. **Added HTTPS parameter**: Added `use-https: true` to enable HTTPS cloning
3. **Updated artifact action**: Updated to use pinned version for security

## Problem Solved

The workflow was failing because:
- The action was trying to use SSH cloning without proper SSH keys
- This caused "Host key verification failed" errors for all repositories
- The `@initial-update` branch was an older version without proper HTTPS support

## Expected Result

With these changes, the workflow should:
- ✅ Clone repositories over HTTPS (no SSH keys needed)
- ✅ Avoid SSH host key verification issues  
- ✅ Successfully complete the repository analysis
- ✅ Generate proper reports for all projects

The gerrit-clone-action now has proper HTTPS support and debug output to help troubleshoot any remaining issues.